### PR TITLE
Avoid redundant checkmate verification

### DIFF
--- a/client/src/gameLogic/validMoves.ts
+++ b/client/src/gameLogic/validMoves.ts
@@ -419,11 +419,11 @@ function validMoves(piece: PieceType, position: Position, gameState: GameStateTy
   }
     
   if (isOpponentKingInCheck) {
-    
+
     gameState.checkStatus[opponentColor] = true;
     // Create a piece with the opposite color to check if colorToCheck is in checkmate
-    isKingInCheckMate = isCheckmate(tempGameState, piece, position, lastPosition);
-    
+    isKingInCheckMate = isCheckmate(tempGameState, piece, position, lastPosition, true);
+
   }
   
  
@@ -654,7 +654,13 @@ function isSquareUnderAttack(square: Position, gameState: GameStateType, attacke
   
 
 
-function isCheckmate(gameState: GameStateType, piece: PieceType, position: Position, targetPosition: Position): boolean {
+function isCheckmate(
+  gameState: GameStateType,
+  piece: PieceType,
+  position: Position,
+  targetPosition: Position,
+  kingAlreadyInCheck = false
+): boolean {
   // Get the opponent's color
   const opponentColor = piece.color === 'white' ? 'black' : 'white';
   const currentColor = piece.color === 'white' || piece.color === 'black' ? piece.color : 'white';
@@ -663,9 +669,24 @@ function isCheckmate(gameState: GameStateType, piece: PieceType, position: Posit
   const checkPosition = gameState.kingPositions[opponentColor];
   const threateningSquares = gameState.threateningPiecesPositions[currentColor] || [];
 
-  // First check if the opponent king is in check
-  if (!isCheckOpponent(gameState, threateningSquares, opponentPlayerNumber, checkPosition, piece, position, playerNumber, targetPosition, matchFoundInDirection, currentColor).isKingInCheck) {
-    return false;
+  // First check if the opponent king is in check unless the caller already confirmed
+  if (!kingAlreadyInCheck) {
+    if (
+      !isCheckOpponent(
+        gameState,
+        threateningSquares,
+        opponentPlayerNumber,
+        checkPosition,
+        piece,
+        position,
+        playerNumber,
+        targetPosition,
+        matchFoundInDirection,
+        currentColor
+      ).isKingInCheck
+    ) {
+      return false;
+    }
   }
 
   // Find all of the opponent's pieces


### PR DESCRIPTION
## Summary
- skip re-checking opponent king when checkmate is evaluated after check is confirmed
- add `kingAlreadyInCheck` flag to `isCheckmate`

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b99afd5544832b8e236b07fedc7824