### PR TITLE
Simplify piece color check in isCheck

### DIFF
--- a/client/src/gameLogic/isCheck.ts
+++ b/client/src/gameLogic/isCheck.ts
@@ -123,10 +123,7 @@ function isCheck(gameState: GameStateType, threateningSquares: ThreateningSquare
         squarePiece = gameState.board[y!][x!];
          // Log the current square and squarePiece color
           
-        if (!squarePiece || squarePiece.color === 'none' || !squarePiece.color) {
-           // Log the result
-          continue; // Skip to the next iteration of the inner loop if the squarePiece is empty or has no color
-        }
+        if (!squarePiece || squarePiece.color === 'none') continue;
         const color = playerNumber === 1 ? 'black' : 'white';
         const opponentColor = color === 'white' ? 'black' : 'white';
         if (squarePiece.color === color ) {


### PR DESCRIPTION
## Summary
- streamline squarePiece validation in `isCheck` by removing redundant color check

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing Jest types)*
- `npx tsc --noEmit src/gameLogic/isCheck.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b99af84d5c832bbce81eb012cebc01