### PR TITLE
refactor: remove redundant canBlock call

### DIFF
--- a/client/src/gameLogic/isCheckOpponent.ts
+++ b/client/src/gameLogic/isCheckOpponent.ts
@@ -370,11 +370,8 @@ if (firstTriggeringCurrentPieceIndex !== -1) {
 // === Save our check detection result before canBlock can modify it ===
 // let finalCheckStatus = isKingInCheck;
 
-// Store the direction that was found during check detection
-const detectedDirection = gameState.checkStatus.direction;
-// Call canBlock but don't let it override our check detection
-canBlock(gameState, threateningSquares, checkPosition, currentPlayerColor, piece as PieceType);
-  
+ // Store the direction that was found during check detection
+ const detectedDirection = gameState.checkStatus.direction;
 
 const isKingInCheckMate: boolean = false; // Checkmate logic is separate
   const firstTriggeringOpponentPiece = firstTriggeringCurrentPiece;


### PR DESCRIPTION
## Summary
- Remove duplicate canBlock invocation in check detection logic
- Preserve results of initial canBlock call when returning detection data

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99af9b6d0832babe942bd310fcbd4