### PR TITLE
fix: join active rooms when loading saved game

### DIFF
--- a/server/dist/src/server.js
+++ b/server/dist/src/server.js
@@ -345,14 +345,38 @@ io.on('connection', (socket) => {
     };
     //Create a room
     socket.on('createRoom', (roomCode, gameState) => {
-        rooms[roomCode] = [socket.id];
-        const playerNumber = 1;
-        players[socket.id] = { roomCode, playerNumber };
-        console.log('players', players, roomCode, playerNumber, gameState);
-        socket.emit('playerNumber', playerNumber);
-        socket.emit('gameState', gameState);
-        socket.emit('createRoom', roomCode);
-        roomStates[roomCode] = gameState;
+        // If the room already exists, join it instead of overwriting
+        if (rooms[roomCode] && rooms[roomCode].length > 0) {
+            socket.join(roomCode);
+            if (!rooms[roomCode].includes(socket.id)) {
+                rooms[roomCode].push(socket.id);
+            }
+            const otherPlayerSocketId = rooms[roomCode].find(id => id !== socket.id);
+            const playerNumber = otherPlayerSocketId && players[otherPlayerSocketId]
+                ? players[otherPlayerSocketId].playerNumber === 1 ? 2 : 1
+                : 1;
+            players[socket.id] = { roomCode, playerNumber };
+            socket.emit('playerNumber', playerNumber);
+            if (gameState) {
+                roomStates[roomCode] = gameState;
+                const others = rooms[roomCode].filter(id => id !== socket.id);
+                io.to(others).emit('loadSaveGame', roomCode, roomStates[roomCode]);
+            }
+            socket.emit('gameState', roomStates[roomCode]);
+            socket.emit('createRoom', roomCode);
+        }
+        else {
+            rooms[roomCode] = [socket.id];
+            const playerNumber = 1;
+            players[socket.id] = { roomCode, playerNumber };
+            socket.join(roomCode);
+            socket.emit('playerNumber', playerNumber);
+            socket.emit('gameState', gameState);
+            socket.emit('createRoom', roomCode);
+            if (gameState) {
+                roomStates[roomCode] = gameState;
+            }
+        }
         // Broadcast updated room list
         broadcastAvailableRooms();
     });

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -428,14 +428,41 @@ io.on('connection', (socket: Socket) => {
     };
     //Create a room
     socket.on('createRoom', (roomCode:string, gameState?:GameStateType) => {
-        rooms[roomCode] = [socket.id];
-        const playerNumber = 1;
-        players[socket.id] = { roomCode, playerNumber };
-        console.log('players', players, roomCode, playerNumber, gameState)
-        socket.emit('playerNumber', playerNumber);
-        socket.emit('gameState', gameState)
-        socket.emit('createRoom', roomCode)
-        roomStates[roomCode] = gameState!;
+        // If the room already exists, join it instead of overwriting
+        if (rooms[roomCode] && rooms[roomCode].length > 0) {
+            socket.join(roomCode);
+            if (!rooms[roomCode].includes(socket.id)) {
+                rooms[roomCode].push(socket.id);
+            }
+
+            const otherPlayerSocketId = rooms[roomCode].find(id => id !== socket.id);
+            const playerNumber = otherPlayerSocketId && players[otherPlayerSocketId]
+                ? players[otherPlayerSocketId].playerNumber === 1 ? 2 : 1
+                : 1;
+
+            players[socket.id] = { roomCode, playerNumber };
+            socket.emit('playerNumber', playerNumber);
+
+            if (gameState) {
+                roomStates[roomCode] = gameState;
+                const others = rooms[roomCode].filter(id => id !== socket.id);
+                io.to(others).emit('loadSaveGame', roomCode, roomStates[roomCode]);
+            }
+
+            socket.emit('gameState', roomStates[roomCode]);
+            socket.emit('createRoom', roomCode);
+        } else {
+            rooms[roomCode] = [socket.id];
+            const playerNumber = 1;
+            players[socket.id] = { roomCode, playerNumber };
+            socket.join(roomCode);
+            socket.emit('playerNumber', playerNumber);
+            socket.emit('gameState', gameState);
+            socket.emit('createRoom', roomCode);
+            if (gameState) {
+                roomStates[roomCode] = gameState;
+            }
+        }
 
         // Broadcast updated room list
         broadcastAvailableRooms();


### PR DESCRIPTION
## Summary
- ensure server joins existing rooms when loading a saved game rather than overwriting
- broadcast loaded game state to other players and update compiled output

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99cccf9ec832b8e619b31bad5a838