### PR TITLE
Add castling to highlighted tiles

### DIFF
--- a/client/src/__tests__/gameLogic/highlightCastling.test.ts
+++ b/client/src/__tests__/gameLogic/highlightCastling.test.ts
@@ -1,0 +1,57 @@
+import validMoves from '../../gameLogic/validMoves';
+import { createEmptyBoard, createPiece } from '../../testUtils/testBoards';
+import { GameStateType, PiecePositions, PieceType, Position, ValidMoveReturn } from '../../types/clientTypes';
+
+describe('highlight castling moves', () => {
+  test('king highlights castling squares', () => {
+    const board = createEmptyBoard();
+
+    // Create pieces needed for castling
+    const whiteKing = createPiece('king', 'white', [7, 4], 0);
+    const rookQueenside = createPiece('rook', 'white', [7, 0], 1);
+    const rookKingside = createPiece('rook', 'white', [7, 7], 2);
+
+    board[7][4] = whiteKing;
+    board[7][0] = rookQueenside;
+    board[7][7] = rookKingside;
+
+    const piecePositions = {
+      white: [whiteKing, rookQueenside, rookKingside] as PiecePositions[],
+      black: [] as PiecePositions[],
+    };
+
+    const gameState: GameStateType = {
+      board,
+      history: [],
+      turn: 'white',
+      kingPositions: { black: [0, 4], white: [7, 4] },
+      threateningPiecesPositions: { black: [], white: [] },
+      piecePositions,
+      checkStatus: { black: false, white: false, direction: -1 },
+      checkmateStatus: { black: false, white: false },
+      username1: '',
+      username2: '',
+    };
+
+    const playerNumber = 2; // white
+
+    const basicResult = validMoves(whiteKing, whiteKing.position as Position, gameState, playerNumber, whiteKing.position as Position) as ValidMoveReturn;
+    let moves = basicResult.moves || [];
+
+    // Manually check castling destinations
+    const castleTargets: Position[] = [
+      [7, 6],
+      [7, 2],
+    ];
+
+    castleTargets.forEach(target => {
+      const castleResult = validMoves(whiteKing, whiteKing.position as Position, gameState, playerNumber, target) as ValidMoveReturn;
+      if (castleResult.canCastle) {
+        moves.push(target);
+      }
+    });
+
+    expect(moves).toEqual(expect.arrayContaining([[7, 6], [7, 2]]));
+  });
+});
+

--- a/client/src/components/Chess.tsx
+++ b/client/src/components/Chess.tsx
@@ -434,12 +434,31 @@ const Chess: React.FC<Props> = (props) => {
         
         // Get valid moves using the same code path as handleDrop
         const result = validMoves(piece, position, gameState, playerNumber, position);
-        
-        // Handle different possible return types from validMoves
+
         if (!result) return [];
-        if (Array.isArray(result)) return result; // Handle Position[] return type
-        if ('moves' in result) return result.moves; // Handle ValidMovesResult return type
-        return []; // Fallback for any other case
+
+        // Normalize result to a moves array
+        let moves: Position[] = [];
+        if (Array.isArray(result)) {
+            moves = result;
+        } else if ('moves' in result) {
+            moves = result.moves || [];
+
+            // Include castling moves when selecting the king
+            if (piece.type === 'king') {
+                const castleTargets: Position[] = [
+                    [position[0], position[1] + 2],
+                    [position[0], position[1] - 2]
+                ];
+                castleTargets.forEach(target => {
+                    const castleResult = validMoves(piece, position, gameState, playerNumber, target) as ValidMovesResult;
+                    if (castleResult && 'canCastle' in castleResult && castleResult.canCastle) {
+                        moves.push(target);
+                    }
+                });
+            }
+        }
+        return moves; // Fallback for any other case is empty array
     };
     const handleSquareClick = (event: React.MouseEvent, position: Position) => {
         event.stopPropagation(); // Prevent bubbling


### PR DESCRIPTION
## Summary
- include castling moves when selecting the king so highlighted squares show castle destinations
- test castling highlight behavior

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99d234b50832bb1d1e6ae20e2444c