### PR TITLE
Allow capturing piece while in check

### DIFF
--- a/client/src/gameLogic/validMoves.ts
+++ b/client/src/gameLogic/validMoves.ts
@@ -82,10 +82,19 @@ function validMoves(piece: PieceType, position: Position, gameState: GameStateTy
     // Create a copy of the game state
     const tempGameState = JSON.parse(JSON.stringify(gameState));
     const currentColor = piece.color;
-    const threateningPieces = currentColor !== 'none' ? gameState.threateningPiecesPositions[currentColor as 'black' | 'white'] : [];
-    
-    if (currentColor !== 'none' && gameState.threateningPiecesPositions[currentColor] && threateningPieces[gameState.checkStatus.direction] === endPos) {
-      
+    const threateningPieces =
+      currentColor !== 'none'
+        ? gameState.threateningPiecesPositions[currentColor as 'black' | 'white']
+        : [];
+
+    // If the move captures the checking piece, it's always allowed
+    const captureTarget = threateningPieces[gameState.checkStatus.direction];
+    if (
+      currentColor !== 'none' &&
+      Array.isArray(captureTarget) &&
+      captureTarget[0] === endPos[0] &&
+      captureTarget[1] === endPos[1]
+    ) {
       return false;
     }
     // Get current player's color
@@ -94,22 +103,34 @@ function validMoves(piece: PieceType, position: Position, gameState: GameStateTy
     const opponentPlayerNumber = currentColor === 'white' ? 1 : 2;
     
     // Make the hypothetical move
-    tempGameState.board[startPos[0]!][startPos[1]!] = { 
-      type: 'empty', 
-      color: 'none', 
-      hasMoved: false, 
-      position: [startPos[0], startPos[1]] 
+    tempGameState.board[startPos[0]!][startPos[1]!] = {
+      type: 'empty',
+      color: 'none',
+      hasMoved: false,
+      position: [startPos[0], startPos[1]]
     };
-    
+
     // Remember what was at the target position (in case of capture)
-    //const capturedPiece = tempGameState.board[endPos[0]!][endPos[1]!];
-    
+    const capturedPiece = tempGameState.board[endPos[0]!][endPos[1]!];
+
     // Move the piece
     tempGameState.board[endPos[0]!][endPos[1]!] = {
       ...piece,
       position: endPos,
       hasMoved: true
     };
+
+    // Update piece positions for both players to reflect the hypothetical move
+    if (capturedPiece.color !== 'none') {
+      tempGameState.piecePositions[capturedPiece.color] = tempGameState.piecePositions[capturedPiece.color].filter(
+        p => p.position[0] !== endPos[0] || p.position[1] !== endPos[1]
+      );
+    }
+    tempGameState.piecePositions[currentColor] = tempGameState.piecePositions[currentColor].map(p =>
+      p.position[0] === startPos[0] && p.position[1] === startPos[1]
+        ? { ...p, position: endPos, hasMoved: true }
+        : p
+    );
     
     // Update king position if we're moving the king
     const kingPosition = {...gameState.kingPositions};


### PR DESCRIPTION
## Summary
- Correct `wouldExposeKingToCheck` to permit capturing the checking piece
- Update hypothetical game state to remove captured pieces when evaluating moves

## Testing
- `npx jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68b99c879244832bbcd21959143abfd8