### PR TITLE
refactor: use piecePositions for opponent pieces

### DIFF
--- a/client/src/gameLogic/validMoves.ts
+++ b/client/src/gameLogic/validMoves.ts
@@ -667,17 +667,8 @@ function isCheckmate(gameState: GameStateType, piece: PieceType, position: Posit
   if (!isCheckOpponent(gameState, threateningSquares, opponentPlayerNumber, checkPosition, piece, position, playerNumber, targetPosition, matchFoundInDirection, currentColor).isKingInCheck) {
     return false;
   }
-
   // Find all of the opponent's pieces
-  const opponentPieces: PieceType[] = [];
-  for (let row = 0; row < 8; row++) {
-    for (let col = 0; col < 8; col++) {
-      const currentPiece = gameState.board[row][col];
-      if (currentPiece.color === opponentColor) {
-        opponentPieces.push(currentPiece);
-      }
-    }
-  }
+  const opponentPieces = gameState.piecePositions[opponentColor];
 
   // Check if any of the opponent's pieces have valid moves that would get the king out of check
   for (const opponentPiece of opponentPieces) {


### PR DESCRIPTION
## Summary
- streamline opponent piece lookup by using `piecePositions`

## Testing
- `npm test` (fails: Cannot find namespace 'React')
- `npm run lint` (fails: ESLint couldn't find an eslint.config file)


------
https://chatgpt.com/codex/tasks/task_e_68b99afdf08c832bbe2bddec0ef5ef24