### PR TITLE
Fix check threat detection

### DIFF
--- a/client/src/gameLogic/isCheck.ts
+++ b/client/src/gameLogic/isCheck.ts
@@ -255,8 +255,11 @@ function isCheck(gameState: GameStateType, threateningSquares: ThreateningSquare
   return true; // Return false if no blocking piece is found after checking all pieces
 }
 
-
-canBlock(gameState, threateningSquares as Position[][] | Position[], opponentColor, piece); 
+// Preserve the detected check status before calling canBlock,
+// which mutates the shared isKingInCheck flag
+const checkStatusBeforeBlock = isKingInCheck;
+canBlock(gameState, threateningSquares as Position[][] | Position[], opponentColor, piece);
+isKingInCheck = checkStatusBeforeBlock;
 
 // Assuming firstTriggeringOpponentPiece is a coordinate like [y, x]
 let firstTriggeringOpponentPieceIndex = -1;

--- a/client/src/gameLogic/isCheckOpponent.ts
+++ b/client/src/gameLogic/isCheckOpponent.ts
@@ -194,8 +194,8 @@ if (isKnightAttackingPosition(gameState.kingPositions[opponentColor], gameState,
     }
   }
 
-  // *** CRITICAL FIX: Save the check status BEFORE canBlock modifies it ***
-  let finalCheckStatus = isKingInCheck;
+  // Save the check status before canBlock potentially modifies it
+  const finalCheckStatus = isKingInCheck;
 
 
   function canBlock(gameState: GameStateType, threateningSquares: ThreateningSquares, 
@@ -368,19 +368,22 @@ if (firstTriggeringCurrentPieceIndex !== -1) {
  // === Save our check detection result before canBlock can modify it ===
  //const isInCheck = isKingInCheck;
 // === Save our check detection result before canBlock can modify it ===
-// let finalCheckStatus = isKingInCheck;
 
  // Store the direction that was found during check detection
  const detectedDirection = gameState.checkStatus.direction;
 
 const isKingInCheckMate: boolean = false; // Checkmate logic is separate
-  const firstTriggeringOpponentPiece = firstTriggeringCurrentPiece;
-  if (piece.type === 'pawn') {
-    finalCheckStatus;
-  } else {
-    finalCheckStatus = isKingInCheck;
-  }
-  return { isOpponentKingInCheck: finalCheckStatus, isKingInCheckMate, loser: opponentColor, slicedThreateningSquares, checkDirection: detectedDirection, firstTriggeringOpponentPiece };
+const firstTriggeringOpponentPiece = firstTriggeringCurrentPiece;
+
+// Return the original check status captured before calling canBlock
+return {
+  isOpponentKingInCheck: finalCheckStatus,
+  isKingInCheckMate,
+  loser: opponentColor,
+  slicedThreateningSquares,
+  checkDirection: detectedDirection,
+  firstTriggeringOpponentPiece
+};
 }
 
 export default isCheckOpponent;


### PR DESCRIPTION
## Summary
- retain opponent check status after canBlock to preserve original detection
- restore check state when evaluating blocking logic to detect all threatening pieces

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b99d5cbfe8832ba31cb091d2fba4f4