### PR TITLE
fix turn state on disconnect

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -586,7 +586,10 @@ io.on('connection', (socket: Socket) => {
         console.log('disconnected player', player)
         if (player) {
             const roomCode = player.roomCode;
-            socket.broadcast.to(roomCode).emit('turn', 0);
+            // Ensure remaining players in the room receive the turn reset
+            // Using io.to ensures the message is delivered even if the
+            // disconnecting socket has already left the room
+            io.to(roomCode).emit('turn', 0 as any);
             
             // Replace the problematic code with this:
             if (rooms[roomCode]) {


### PR DESCRIPTION
## Summary
- ensure players receive turn reset when an opponent disconnects

## Testing
- `npx jest` *(fails: 403 Forbidden retrieving jest from registry)*


------
https://chatgpt.com/codex/tasks/task_e_68b99cf96ae4832bb2f7753c547fbf0c