### PR TITLE
Cache selected piece before clearing during square clicks

### DIFF
--- a/client/src/components/Chess.tsx
+++ b/client/src/components/Chess.tsx
@@ -499,20 +499,20 @@ const Chess: React.FC<Props> = (props) => {
             lastDragOverPosition.current = position;
             
             // Execute the same move logic as in handleDrop
+            const selectedPieceCopy = props.selectedPiece;
             const fakeEvent = {
                 preventDefault: () => {},
                 dataTransfer: {
                     getData: (key: string) => {
-                        if (key === 'piece') return JSON.stringify(props.selectedPiece);
+                        if (key === 'piece') return JSON.stringify(selectedPieceCopy);
                         if (key === 'position') return JSON.stringify(piecePosition);
                         return '';
                     }
                 }
             } as unknown as React.DragEvent;
-            
+
             // Clear selection and highlights BEFORE calling handleDrop
             // to avoid race conditions
-            //const selectedPieceCopy = props.selectedPiece;
             props.setSelectedPiece(null);
             props.setHighlightedTiles([]);
             


### PR DESCRIPTION
## Summary
- Cache `selectedPiece` before clearing it in `handleSquareClick`
- Use cached piece in synthetic `dataTransfer` event

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7c5ed564832b8324aa0bc8fb5f2f