### PR TITLE
Fix piece cloning in handleSquareClick

### DIFF
--- a/client/src/components/Chess.tsx
+++ b/client/src/components/Chess.tsx
@@ -482,7 +482,7 @@ const Chess: React.FC<Props> = (props) => {
         
         if (isValidMove) {
             // Store the original piece position
-            const piecePosition = props.selectedPiece.position as Position;
+            const piecePosition = [...(props.selectedPiece.position as Position)];
             
             
             // Make sure we're not trying to castle onto our own rook
@@ -499,7 +499,7 @@ const Chess: React.FC<Props> = (props) => {
             lastDragOverPosition.current = position;
             
             // Execute the same move logic as in handleDrop
-            const selectedPieceCopy = props.selectedPiece;
+            const selectedPieceCopy = JSON.parse(JSON.stringify(props.selectedPiece));
             const fakeEvent = {
                 preventDefault: () => {},
                 dataTransfer: {


### PR DESCRIPTION
## Summary
- deep-clone selected pieces in `handleSquareClick`
- copy `piecePosition` before emulating drag-and-drop events

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: multiple lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7f25035c832b95c1b4dcb6e3b938