### PR TITLE
Call drop handler before clearing selection

### DIFF
--- a/client/src/components/Chess.tsx
+++ b/client/src/components/Chess.tsx
@@ -511,13 +511,13 @@ const Chess: React.FC<Props> = (props) => {
                 }
             } as unknown as React.DragEvent;
 
-            // Clear selection and highlights BEFORE calling handleDrop
-            // to avoid race conditions
+            // Call the existing handleDrop function with our synthetic event
+            // If state updates interfere, wrap this in setTimeout(() => handleDrop(fakeEvent), 0)
+            handleDrop(fakeEvent);
+
+            // Clear selection and highlights after the move completes
             props.setSelectedPiece(null);
             props.setHighlightedTiles([]);
-            
-            // Call the existing handleDrop function with our synthetic event
-            handleDrop(fakeEvent);
         } else {
             // If clicked on an invalid move square, just deselect
             props.setSelectedPiece(null);


### PR DESCRIPTION
## Summary
- In Chess click-to-move logic, trigger handleDrop before clearing selection and highlights, clarifying ordering and noting setTimeout option.

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm run lint` *(fails: 25 problems, see log)*

------
https://chatgpt.com/codex/tasks/task_e_68bb864b5c04832b8041e1ab5f989d27