### PR TITLE
Enable castling in click-to-move mode

### DIFF
--- a/client/src/components/Chess.tsx
+++ b/client/src/components/Chess.tsx
@@ -498,12 +498,39 @@ const Chess: React.FC<Props> = (props) => {
         
         // Get valid moves using the same code path as handleDrop
         const result = validMoves(piece, position, gameState, playerNumber, position);
-        
-        // Handle different possible return types from validMoves
-        if (!result) return [];
-        if (Array.isArray(result)) return result; // Handle Position[] return type
-        if ('moves' in result) return result.moves; // Handle ValidMovesResult return type
-        return []; // Fallback for any other case
+
+        // Normalize result into an array of positions
+        let moves: Position[] = [];
+        if (result) {
+            if (Array.isArray(result)) {
+                moves = result;
+            } else if ('moves' in result) {
+                moves = result.moves;
+            }
+        }
+
+        // Special handling for castling in click-to-move mode
+        // Castling is triggered by clicking the rook, so we need to highlight
+        // the rook squares when castling is permitted. Reuse existing logic in
+        // validMoves to verify castling by testing each rook position.
+        if (piece.type === 'king') {
+            const potentialRooks: Position[] = [
+                [position[0], 0], // Queenside rook
+                [position[0], 7]  // Kingside rook
+            ];
+
+            potentialRooks.forEach(rookPos => {
+                const castleResult = validMoves(piece, position, gameState, playerNumber, rookPos);
+                if (castleResult && !Array.isArray(castleResult) && castleResult.canCastle) {
+                    // Only add if not already in moves
+                    if (!moves.some(m => m[0] === rookPos[0] && m[1] === rookPos[1])) {
+                        moves.push(rookPos);
+                    }
+                }
+            });
+        }
+
+        return moves; // Fallback for any other case
     };
     const handleSquareClick = (event: React.MouseEvent, position: Position) => {
         event.stopPropagation(); // Prevent bubbling


### PR DESCRIPTION
## Summary
- highlight rooks when castling is legal for click-to-move
- reuse existing validMoves logic to validate castling and prevent invalid rook selection

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c02cced50c832b98c48a8f56359832