### PR TITLE
fix: correct black queenside castling

### DIFF
--- a/client/src/__tests__/gameLogic/specialMoves.test.ts
+++ b/client/src/__tests__/gameLogic/specialMoves.test.ts
@@ -265,9 +265,10 @@ describe('Special Chess Moves Tests', () => {
       const position = whiteKing.position as Position;
       const castlePosition: Position = [7, 6]; // Kingside castle destination
       const result = validMoves(whiteKing, position, gameState, 2, castlePosition) as ValidMoveReturn;
-      
+
       // Verify castling is allowed
       expect(result.canCastle).toBe(true);
+      expect(result.moves).toContainEqual(castlePosition);
     });
 
     test('White king can castle queenside', () => {
@@ -295,9 +296,10 @@ describe('Special Chess Moves Tests', () => {
       const position = whiteKing.position as Position;
       const castlePosition: Position = [7, 2]; // Queenside castle destination
       const result = validMoves(whiteKing, position, gameState, 2, castlePosition) as ValidMoveReturn;
-      
+
       // Verify castling is allowed
       expect(result.canCastle).toBe(true);
+      expect(result.moves).toContainEqual(castlePosition);
     });
 
     test('Black king can castle kingside', () => {
@@ -324,9 +326,10 @@ describe('Special Chess Moves Tests', () => {
       const position = blackKing.position as Position;
       const castlePosition: Position = [0, 6]; // Kingside castle destination
       const result = validMoves(blackKing, position, gameState, 1, castlePosition) as ValidMoveReturn;
-      
+
       // Verify castling is allowed
       expect(result.canCastle).toBe(true);
+      expect(result.moves).toContainEqual(castlePosition);
     });
 
     test('Black king can castle queenside', () => {
@@ -357,6 +360,7 @@ describe('Special Chess Moves Tests', () => {
 
         // Verify castling is allowed
         expect(result.canCastle).toBe(true);
+        expect(result.moves).toContainEqual(castlePosition);
     });
 
     test('Black king cannot castle queenside through check', () => {

--- a/client/src/__tests__/gameLogic/specialMoves.test.ts
+++ b/client/src/__tests__/gameLogic/specialMoves.test.ts
@@ -359,6 +359,35 @@ describe('Special Chess Moves Tests', () => {
         expect(result.canCastle).toBe(true);
     });
 
+    test('Black king cannot castle queenside through check', () => {
+      // Create a black king that has not moved
+      const blackKing = createPiece('king', 'black', [0, 4], 2);
+      blackKing.hasMoved = false;
+
+      // Create a black rook that has not moved
+      const blackRook = createPiece('rook', 'black', [0, 0], 3);
+      blackRook.hasMoved = false;
+
+      // Create an attacking white rook targeting the path
+      const whiteRook = createPiece('rook', 'white', [1, 3], 4);
+
+      // Create the game state with these pieces
+      const gameState = createTestBoard([blackKing, blackRook, whiteRook]);
+
+      // Ensure the spaces between king and rook are empty
+      gameState.board[0][1] = { type: 'empty', color: 'none', position: [0, 1], hasMoved: false };
+      gameState.board[0][2] = { type: 'empty', color: 'none', position: [0, 2], hasMoved: false };
+      gameState.board[0][3] = { type: 'empty', color: 'none', position: [0, 3], hasMoved: false };
+
+      // Get valid moves for the king
+      const position = blackKing.position as Position;
+      const castlePosition: Position = [0, 2]; // Queenside castle destination
+      const result = validMoves(blackKing, position, gameState, 1, castlePosition) as ValidMoveReturn;
+
+      // Verify castling is not allowed
+      expect(result.canCastle).toBe(false);
+    });
+
     test('King cannot castle if it has moved', () => {
       // Create a white king that HAS moved
       const whiteKing = createPiece('king', 'white', [7, 4], 2);

--- a/client/src/gameLogic/validMoves.ts
+++ b/client/src/gameLogic/validMoves.ts
@@ -937,7 +937,7 @@ for (const move of moves) {
   const exists = filteredMoves.some(m => m[0] === move[0] && m[1] === move[1]);
   if (!exists) {
     // Add to filteredMoves if it's not there (like castling moves)
-    //filteredMoves.push(move);
+    filteredMoves.push(move);
   }
 }
 

--- a/client/src/gameLogic/validMoves.ts
+++ b/client/src/gameLogic/validMoves.ts
@@ -1035,39 +1035,6 @@ if (isOpponentKingInCheck) {
   console.log(`Checkmate determination: ${isKingInCheckMate ? 'CHECKMATE' : 'NOT CHECKMATE'}`);
 }
 
-// Check if the Black king can castle
-if (piece.type === 'king' && piece.color === 'black' && !piece.hasMoved) {
-  // Check if this is the black king's initial position
-  if (position[0] === 0 && position[1] === 4) {
-    // Check queenside rook
-    const queenRook = gameState.board[0][0];
-    if (queenRook.type === 'rook' && queenRook.color === 'black' && !queenRook.hasMoved) {
-      // Check if squares between king and rook are empty
-      const arePathsEmpty = gameState.board[0][1].type === 'empty' && 
-                           gameState.board[0][2].type === 'empty' && 
-                           gameState.board[0][3].type === 'empty';
-      
-      if (arePathsEmpty) {
-        // No pieces between king and rook, enable castling
-        canCastle = true;
-      }
-    }
-    
-    // Check kingside rook
-    const kingRook = gameState.board[0][7];
-    if (kingRook.type === 'rook' && kingRook.color === 'black' && !kingRook.hasMoved) {
-      // Check if squares between king and rook are empty
-      const arePathsEmpty = gameState.board[0][5].type === 'empty' && 
-                           gameState.board[0][6].type === 'empty';
-      
-      if (arePathsEmpty) {
-        // No pieces between king and rook, enable castling
-        canCastle = true;
-      }
-    }
-  }
-}
-
 return {
   moves: filteredMoves,
   threateningSquares: {


### PR DESCRIPTION
## Summary
- remove redundant black-only castling logic that always enabled queenside castling
- add test ensuring black cannot castle queenside when path is under attack

## Testing
- `npm --prefix client install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm --prefix client test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c03a156420832b8fc31cd387c9d20f