### PR TITLE
Persist room game state when players join

### DIFF
--- a/server/dist/src/server.js
+++ b/server/dist/src/server.js
@@ -361,6 +361,8 @@ io.on('connection', (socket) => {
     //Game state
     socket.on('gameState', (gameState, roomCode) => {
         if (rooms[roomCode]) {
+            // Persist the latest state so newcomers receive up-to-date boards
+            roomStates[roomCode] = gameState;
             const otherPlayerSocketId = [...rooms[roomCode]].filter(id => id !== socket.id);
             io.to(otherPlayerSocketId).emit('gameState', gameState);
         }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -531,6 +531,9 @@ io.on('connection', (socket: Socket) => {
     //Game state
     socket.on('gameState', (gameState: GameStateType, roomCode:string) => {
         if (rooms[roomCode]) {
+            // Persist the latest state so newcomers receive up-to-date boards
+            roomStates[roomCode] = gameState;
+
             const otherPlayerSocketId = [...rooms[roomCode]].filter(id => id !== socket.id);
             io.to(otherPlayerSocketId).emit('gameState', gameState);
         } else {


### PR DESCRIPTION
## Summary
- Persist latest game state per room on `gameState` events
- Ensure new players joining an existing room receive the current board

## Testing
- `npm --prefix server test` *(fails: sh: 1: jest: not found)*
- `npm --prefix client test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c140fd2720832bac6e255464dc14d7