### PR TITLE
Fix pawn promotion overlay and asset loading

### DIFF
--- a/client/src/components/Chess.tsx
+++ b/client/src/components/Chess.tsx
@@ -11,6 +11,7 @@ import calculateThreateningSquares from '../gameLogic/calculateThreateningSquare
 import BoardButtons from './BoardButtons';
 import { polyfill } from "mobile-drag-drop";
 import { scrollBehaviourDragImageTranslateOverride } from "mobile-drag-drop/scroll-behaviour";
+import { getPieceIcon } from '../assets/icons';
 // import BoardTimer from './BoardTimer';
 // import resetGameState from '../gameLogic/resetGameState';
 
@@ -765,23 +766,25 @@ const Chess: React.FC<Props> = (props) => {
                 <BoardButtons setTurnState={setTurnState} setWinner={setWinner} setGameState={setGameState} gameState={gameState} roomCode={roomCode} />
             </div>
             
-            {/* Add Promotion Dialog */}
+            {/* Pawn Promotion Overlay */}
             {showPromotionDialog && (
-                <div className="promotion-dialog">
-                    <h3>Choose promotion piece:</h3>
-                    <div className="promotion-options">
-                        {['queen', 'rook', 'bishop', 'knight'].map(piece => (
-                            <div 
-                                key={piece} 
-                                className="promotion-piece"
-                                onClick={() => handlePromotionSelection(piece as 'queen' | 'rook' | 'bishop' | 'knight')}
-                            >
-                                <img 
-                                    src={`/src/assets/${piece}${currentPlayerColor.charAt(0).toUpperCase() + currentPlayerColor.slice(1)}.svg`} 
-                                    alt={piece} 
-                                />
-                            </div>
-                        ))}
+                <div className="promotion-overlay">
+                    <div className="promotion-dialog">
+                        <h3>Choose promotion piece:</h3>
+                        <div className="promotion-options">
+                            {['queen', 'rook', 'bishop', 'knight'].map(piece => (
+                                <div
+                                    key={piece}
+                                    className="promotion-piece"
+                                    onClick={() => handlePromotionSelection(piece as 'queen' | 'rook' | 'bishop' | 'knight')}
+                                >
+                                    <img
+                                        src={getPieceIcon(piece as 'queen' | 'rook' | 'bishop' | 'knight', currentPlayerColor as 'white' | 'black')}
+                                        alt={piece}
+                                    />
+                                </div>
+                            ))}
+                        </div>
                     </div>
                 </div>
             )}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -492,3 +492,37 @@ form>input {
   animation: shake 0.5s;
   border-color: red !important;
 }
+
+/* Pawn promotion overlay */
+.promotion-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.promotion-dialog {
+  background-color: #fff;
+  color: #000;
+  padding: 20px;
+  border-radius: 8px;
+  text-align: center;
+}
+
+.promotion-options {
+  display: flex;
+  gap: 10px;
+  margin-top: 10px;
+}
+
+.promotion-piece img {
+  width: 50px;
+  height: 50px;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- load pawn promotion piece icons via bundled imports
- show promotion choices in a centered overlay with translucent background

## Testing
- `npm install` *(fails: 403 Forbidden retrieving jest)*
- `npm test` *(fails: jest: not found)*
- `npm run lint` *(fails: 9 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68c147adefb8832b89533adfc855a1f2