### PR TITLE
Fix pawn promotion asset loading with overlay menu

### DIFF
--- a/client/src/components/Chess.tsx
+++ b/client/src/components/Chess.tsx
@@ -6,9 +6,10 @@ import validMoves from '../gameLogic/validMoves'
 import isDraw from '../gameLogic/isDraw'
 import Board from './Board';
 import GameOver from './GameOver';
-import { Props, Position, PieceType, GameStateType, ValidMovesResult } from '../types/clientTypes';
+import { Props, Position, PieceType, GameStateType, ValidMovesResult, PieceColor, PieceNameWithoutNone } from '../types/clientTypes';
 import calculateThreateningSquares from '../gameLogic/calculateThreateningSquares';
 import BoardButtons from './BoardButtons';
+import { getPieceIcon } from '../assets/icons';
 import { polyfill } from "mobile-drag-drop";
 import { scrollBehaviourDragImageTranslateOverride } from "mobile-drag-drop/scroll-behaviour";
 // import BoardTimer from './BoardTimer';
@@ -765,42 +766,46 @@ const Chess: React.FC<Props> = (props) => {
                 <BoardButtons setTurnState={setTurnState} setWinner={setWinner} setGameState={setGameState} gameState={gameState} roomCode={roomCode} />
             </div>
             
-            {/* Add Promotion Dialog */}
-            {showPromotionDialog && (
-                <div className="promotion-dialog">
-                    <h3>Choose promotion piece:</h3>
-                    <div className="promotion-options">
-                        {['queen', 'rook', 'bishop', 'knight'].map(piece => (
-                            <div 
-                                key={piece} 
-                                className="promotion-piece"
-                                onClick={() => handlePromotionSelection(piece as 'queen' | 'rook' | 'bishop' | 'knight')}
-                            >
-                                <img 
-                                    src={`/src/assets/${piece}${currentPlayerColor.charAt(0).toUpperCase() + currentPlayerColor.slice(1)}.svg`} 
-                                    alt={piece} 
-                                />
+            <div className="board-container">
+                {showPromotionDialog && (
+                    <div className="promotion-overlay">
+                        <div className="promotion-dialog">
+                            <h3>Choose promotion piece:</h3>
+                            <div className="promotion-options">
+                                {['queen', 'rook', 'bishop', 'knight'].map(piece => (
+                                    <div
+                                        key={piece}
+                                        className="promotion-piece"
+                                        onClick={() => handlePromotionSelection(piece as 'queen' | 'rook' | 'bishop' | 'knight')}
+                                    >
+                                        <img
+                                            src={getPieceIcon(piece as PieceNameWithoutNone, currentPlayerColor as PieceColor)}
+                                            alt={`${currentPlayerColor} ${piece}`}
+                                        />
+                                    </div>
+                                ))}
                             </div>
-                        ))}
+                        </div>
                     </div>
-                </div>
-            )}
-            
-            <Board 
-                setTurnState={setTurnState} 
-                setWinner={setWinner} 
-                gameState={props.gameState} 
-                handleDragStart={handleDragStart} 
-                handleDragEnter={handleDragEnter} 
-                handleDragOver={handleDragOver} 
-                handleDrop={handleDrop}
-                isKingInCheck={isKingInCheck}
-                handlePieceClick={handlePieceClick}
-                handleSquareClick={handleSquareClick}
-                handleBoardClick={handleBoardClick}
-                highlightedTiles={props.highlightedTiles}
-                playerNumber={playerNumber} 
-/>        </div>
+                )}
+
+                <Board
+                    setTurnState={setTurnState}
+                    setWinner={setWinner}
+                    gameState={props.gameState}
+                    handleDragStart={handleDragStart}
+                    handleDragEnter={handleDragEnter}
+                    handleDragOver={handleDragOver}
+                    handleDrop={handleDrop}
+                    isKingInCheck={isKingInCheck}
+                    handlePieceClick={handlePieceClick}
+                    handleSquareClick={handleSquareClick}
+                    handleBoardClick={handleBoardClick}
+                    highlightedTiles={props.highlightedTiles}
+                    playerNumber={playerNumber}
+                />
+            </div>
+        </div>
     );
 }
 export default Chess;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -492,3 +492,43 @@ form>input {
   animation: shake 0.5s;
   border-color: red !important;
 }
+
+.Chess {
+  position: relative
+}
+
+.board-container {
+  position: relative;
+  display: inline-block;
+  margin: 0 auto
+}
+
+.promotion-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: rgba(0, 0, 0, 0.4);
+  z-index: 1000
+}
+
+.promotion-dialog {
+  background-color: #ffffff;
+  padding: 1rem;
+  border-radius: 8px
+}
+
+.promotion-options {
+  display: flex;
+  gap: 0.5rem
+}
+
+.promotion-piece img {
+  width: 3em;
+  height: 3em;
+  cursor: pointer
+}


### PR DESCRIPTION
## Summary
- Load pawn promotion piece icons using helper and overlay selection dialog on board
- Style promotion dialog with centered board overlay and translucent background

## Testing
- `npm test` (fails: Missing script "test")
- `npm test --prefix client` (fails: jest: not found)
- `npm test --prefix server` (fails: jest: not found)


------
https://chatgpt.com/codex/tasks/task_e_68c147adefb8832b89533adfc855a1f2