### PR TITLE
fix: prevent reconnect from resetting turn

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -489,9 +489,17 @@ io.on('connection', (socket: Socket) => {
             console.log(`No moves have been made in room with room code ${roomCode}`);
         }
     });
-    //Turn 
+    //Turn
     socket.on('turn', (playerTurn: 0 | 1 | 2, roomCode: string) => {
+        const player = players[socket.id];
         if (playerTurn !== 0) {
+            // Ignore attempts from a player to set the turn to themselves.
+            if (!player || player.playerNumber === playerTurn) {
+                // Send the correct turn state back to the sender without
+                // altering the stored turn.
+                socket.emit('turn', roomTurnStates[roomCode] ?? playerTurn);
+                return;
+            }
             roomTurnStates[roomCode] = playerTurn;
         }
         if (rooms[roomCode]) {


### PR DESCRIPTION
## Summary
- ignore self-directed turn updates so reconnecting players can't reset turn state

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c14cbcedc8832bac81505570d34c11