### PR TITLE
fix: prevent reconnect from resetting turn

### DIFF
--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -401,7 +401,10 @@ setInterval(() => {
 io.on('connection', (socket: Socket) => {
     //Create a room
     socket.on('createRoom', (roomCode:string, gameState?:GameStateType) => {
-        rooms[roomCode] = [socket.id];
+        if (!rooms[roomCode]) {
+            rooms[roomCode] = [];
+        }
+        rooms[roomCode].push(socket.id);
         const playerNumber = 1;
         players[socket.id] = { roomCode, playerNumber };
         console.log('players', players, roomCode, playerNumber, gameState)
@@ -409,8 +412,11 @@ io.on('connection', (socket: Socket) => {
         socket.emit('gameState', gameState)
         socket.emit('createRoom', roomCode)
         roomStates[roomCode] = gameState!;
-        roomTurnStates[roomCode] = gameState && gameState.turn === 'white' ? 2 : 1;
-        socket.emit('turn', roomTurnStates[roomCode]);
+        if (roomTurnStates[roomCode] === undefined) {
+            roomTurnStates[roomCode] = gameState && gameState.turn === 'white' ? 2 : 1;
+        }
+        // Do not allow moves until two players are present
+        socket.emit('turn', rooms[roomCode].length < 2 ? 0 : roomTurnStates[roomCode]);
 
     });
     //Join a room
@@ -476,7 +482,8 @@ io.on('connection', (socket: Socket) => {
             socket.emit('playerNumber', playerNumber);
         }
         socket.emit('gameState', roomStates[roomCode]);
-        io.to(roomCode).emit('turn', roomTurnStates[roomCode] ?? 1);
+        const turnToEmit = rooms[roomCode].length < 2 ? 0 : (roomTurnStates[roomCode] ?? 1);
+        io.to(roomCode).emit('turn', turnToEmit);
     });
     //Load save game
     socket.on('loadSaveGame', (roomCode:string) => {
@@ -489,18 +496,30 @@ io.on('connection', (socket: Socket) => {
             console.log(`No moves have been made in room with room code ${roomCode}`);
         }
     });
-    //Turn 
+    //Turn
     socket.on('turn', (playerTurn: 0 | 1 | 2, roomCode: string) => {
+        const player = players[socket.id];
+        const roomPlayers = rooms[roomCode] || [];
+
+        // If fewer than two players are in the room, no one can move
+        if (roomPlayers.filter(id => id !== '').length < 2) {
+            socket.emit('turn', 0);
+            return;
+        }
+
         if (playerTurn !== 0) {
+            // Ignore attempts from a player to set the turn to themselves.
+            if (!player || player.playerNumber === playerTurn) {
+                // Send the correct turn state back to the sender without
+                // altering the stored turn.
+                socket.emit('turn', roomTurnStates[roomCode] ?? playerTurn);
+                return;
+            }
             roomTurnStates[roomCode] = playerTurn;
         }
-        if (rooms[roomCode]) {
-            const otherPlayerSocketId = [...rooms[roomCode]].filter(id => id !== socket.id);
-            io.to(otherPlayerSocketId).emit('turn', playerTurn as any);
-            console.log('turn', roomCode, playerTurn)
-        } else {
-            console.log(`No moves have been made in room with room code ${roomCode}`);
-        }
+        const otherPlayerSocketId = roomPlayers.filter(id => id !== socket.id);
+        io.to(otherPlayerSocketId).emit('turn', playerTurn as any);
+        console.log('turn', roomCode, playerTurn)
     });
     //Leave a room
     socket.on('leaveRoom', (roomCode:string) => {


### PR DESCRIPTION
## Summary
- preserve stored turn when players leave and rejoin
- disallow moves until both players have joined

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c14cbcedc8832bac81505570d34c11