### PR TITLE
Highlight en passant capture squares

### DIFF
--- a/client/src/components/Chess.tsx
+++ b/client/src/components/Chess.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import { SocketContext } from "../context/SocketContext";
 import isCheck from '../gameLogic/isCheck'
 import validMoves from '../gameLogic/validMoves'
+import enPassant from '../gameLogic/enPassant'
 import isDraw from '../gameLogic/isDraw'
 import Board from './Board';
 import GameOver from './GameOver';
@@ -527,6 +528,25 @@ const Chess: React.FC<Props> = (props) => {
                     if (!moves.some(m => m[0] === rookPos[0] && m[1] === rookPos[1])) {
                         console.log("Clickcaslting0012", rookPos, moves);
                         moves.push(rookPos);
+                    }
+                }
+            });
+        }
+
+        // Include en passant capture squares in highlight
+        if (piece.type === 'pawn') {
+            const direction = piece.color === 'white' ? -1 : 1;
+            const targets: Position[] = [
+                [position[0]! + direction, position[1]! - 1],
+                [position[0]! + direction, position[1]! + 1]
+            ];
+
+            targets.forEach(target => {
+                const [ty, tx] = target;
+                if (ty >= 0 && ty < 8 && tx >= 0 && tx < 8) {
+                    const epMove = enPassant(piece, target, gameState);
+                    if (epMove && !moves.some(m => m[0] === epMove[0] && m[1] === epMove[1])) {
+                        moves.push(epMove);
                     }
                 }
             });


### PR DESCRIPTION
## Summary
- highlight en passant capture targets when selecting a pawn

## Testing
- `npm --prefix client test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c210834878832baa734682f92dda6c